### PR TITLE
Add `out/` folder to cleanup script

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "gulp dev",
     "build": "gulp build",
-    "clean": "del-cli dist",
+    "clean": "del-cli dist out",
     "start": "node dist/index.js",
     "lint": "concurrently -s --kill-others-on-fail yarn:lint:*",
     "lint:eslint": "eslint --ext .ts,.js .",


### PR DESCRIPTION
Previously, the `out/` folder wasn't removed when running `yarn clean`.

Fixes #10.