### PR TITLE
Added check for model version

### DIFF
--- a/lib/src/utils/parser.ts
+++ b/lib/src/utils/parser.ts
@@ -23,13 +23,19 @@ export const parseXML = (xml: string): Vertabelo => {
     ignoreAttributes: false,
     allowBooleanAttributes: true,
     parseNodeValue: true,
-    parseAttributeValue: true,
+    parseAttributeValue: false,
     arrayMode: false,
     tagValueProcessor: (value) => he.decode(value),
     attrValueProcessor: (value) => he.decode(value, { isAttributeValue: true })
   });
 
-  return parsed as Vertabelo;
+  const vertabelo = parsed as Vertabelo;
+  
+  if (vertabelo.DatabaseModel._VersionId !== "2.4") {
+    throw new Error(`Unknown model version: ${vertabelo.DatabaseModel._VersionId}`);
+  }
+
+  return vertabelo;
 };
 
 export interface AttributeDescription {

--- a/lib/src/utils/transform.ts
+++ b/lib/src/utils/transform.ts
@@ -45,6 +45,7 @@ export interface Counter {
 }
 
 export interface DatabaseModel {
+  _VersionId: string,
   Name: string,
   Description: string,
   DatabaseEngine: DatabaseEngine,


### PR DESCRIPTION
This PR adds a check for the model version of the received XML from Vertabelo. The version was pinned to `2.4`, since this is the current version and the one the app was designed with.

Fixes #12.